### PR TITLE
自分が使うデッキとスキルを選べるようにする

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -373,6 +373,8 @@ PODS:
   - nanopb/decode (1.30905.0)
   - nanopb/encode (1.30905.0)
   - PromisesObjC (1.2.10)
+  - shared_preferences (0.0.1):
+    - Flutter
 
 DEPENDENCIES:
   - cloud_firestore (from `.symlinks/plugins/cloud_firestore/ios`)
@@ -381,6 +383,7 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - Flutter (from `Flutter`)
   - google_sign_in (from `.symlinks/plugins/google_sign_in/ios`)
+  - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
 
 SPEC REPOS:
   trunk:
@@ -421,6 +424,8 @@ EXTERNAL SOURCES:
     :path: Flutter
   google_sign_in:
     :path: ".symlinks/plugins/google_sign_in/ios"
+  shared_preferences:
+    :path: ".symlinks/plugins/shared_preferences/ios"
 
 SPEC CHECKSUMS:
   abseil: 6c8eb7892aefa08d929b39f9bb108e5367e3228f
@@ -452,6 +457,7 @@ SPEC CHECKSUMS:
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
   nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
   PromisesObjC: b14b1c6b68e306650688599de8a45e49fae81151
+  shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 

--- a/lib/controllers/d_setting_controller/d_setting_controller.dart
+++ b/lib/controllers/d_setting_controller/d_setting_controller.dart
@@ -1,25 +1,38 @@
 import 'package:state_notifier/state_notifier.dart';
 
 import '../../models/duelist_setting/duelist_setting.dart';
+import '../../repositories/value_persistence_repository/value_persistence_repo.dart';
 
 class DSettingController extends StateNotifier<DuelistSetting>
     with LocatorMixin {
   DSettingController() : super(const DuelistSetting());
 
+  ValuePersistenceRepository get _sharedPrefs => read();
+
   @override
   void initState() {
     super.initState();
+
+    // TODO: PKC 参加してる人はいい感じに Number ふられるようにする
+    // 登録されていないと 0.
     state = state.copyWith(
-      myDeckID: 'testDeckID',
-      mySkillID: 'testSkillID',
+      pkcNumber: 0,
+      playerNumber: 0,
     );
+
+    _sharedPrefs.getString('myDeckID').then(
+        (deckID) => state = state.copyWith(myDeckID: deckID ?? 'No Selected'));
+    _sharedPrefs.getString('mySkillID').then((skillID) =>
+        state = state.copyWith(mySkillID: skillID ?? 'No Selected'));
   }
 
-  void setMyDeck(String deckID) {
+  void setMyDeck(String deckID) async {
     state = state.copyWith(myDeckID: deckID);
+    await _sharedPrefs.setString('myDeckID', deckID);
   }
 
-  void setMySkill(String skillID) {
+  void setMySkill(String skillID) async {
     state = state.copyWith(mySkillID: skillID);
+    await _sharedPrefs.setString('mySkillID', skillID);
   }
 }

--- a/lib/controllers/d_setting_controller/d_setting_controller.dart
+++ b/lib/controllers/d_setting_controller/d_setting_controller.dart
@@ -1,0 +1,25 @@
+import 'package:state_notifier/state_notifier.dart';
+
+import '../../models/duelist_setting/duelist_setting.dart';
+
+class DSettingController extends StateNotifier<DuelistSetting>
+    with LocatorMixin {
+  DSettingController() : super(const DuelistSetting());
+
+  @override
+  void initState() {
+    super.initState();
+    state = state.copyWith(
+      myDeckID: 'testDeckID',
+      mySkillID: 'testSkillID',
+    );
+  }
+
+  void setMyDeck(String deckID) {
+    state = state.copyWith(myDeckID: deckID);
+  }
+
+  void setMySkill(String skillID) {
+    state = state.copyWith(mySkillID: skillID);
+  }
+}

--- a/lib/models/duelist_setting/duelist_setting.dart
+++ b/lib/models/duelist_setting/duelist_setting.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter/foundation.dart';
+
+part 'duelist_setting.freezed.dart';
+
+@freezed
+abstract class DuelistSetting with _$DuelistSetting {
+  const factory DuelistSetting({
+    @Default('') String myDeckID,
+    @Default('') String mySkillID,
+    @Default(0) int pkcNumber,
+    @Default(0) int playerNumber,
+  }) = _DuelistSetting;
+}

--- a/lib/models/duelist_setting/duelist_setting.freezed.dart
+++ b/lib/models/duelist_setting/duelist_setting.freezed.dart
@@ -1,0 +1,210 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+
+part of 'duelist_setting.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+class _$DuelistSettingTearOff {
+  const _$DuelistSettingTearOff();
+
+// ignore: unused_element
+  _DuelistSetting call(
+      {String myDeckID = '',
+      String mySkillID = '',
+      int pkcNumber = 0,
+      int playerNumber = 0}) {
+    return _DuelistSetting(
+      myDeckID: myDeckID,
+      mySkillID: mySkillID,
+      pkcNumber: pkcNumber,
+      playerNumber: playerNumber,
+    );
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $DuelistSetting = _$DuelistSettingTearOff();
+
+/// @nodoc
+mixin _$DuelistSetting {
+  String get myDeckID;
+  String get mySkillID;
+  int get pkcNumber;
+  int get playerNumber;
+
+  $DuelistSettingCopyWith<DuelistSetting> get copyWith;
+}
+
+/// @nodoc
+abstract class $DuelistSettingCopyWith<$Res> {
+  factory $DuelistSettingCopyWith(
+          DuelistSetting value, $Res Function(DuelistSetting) then) =
+      _$DuelistSettingCopyWithImpl<$Res>;
+  $Res call(
+      {String myDeckID, String mySkillID, int pkcNumber, int playerNumber});
+}
+
+/// @nodoc
+class _$DuelistSettingCopyWithImpl<$Res>
+    implements $DuelistSettingCopyWith<$Res> {
+  _$DuelistSettingCopyWithImpl(this._value, this._then);
+
+  final DuelistSetting _value;
+  // ignore: unused_field
+  final $Res Function(DuelistSetting) _then;
+
+  @override
+  $Res call({
+    Object myDeckID = freezed,
+    Object mySkillID = freezed,
+    Object pkcNumber = freezed,
+    Object playerNumber = freezed,
+  }) {
+    return _then(_value.copyWith(
+      myDeckID: myDeckID == freezed ? _value.myDeckID : myDeckID as String,
+      mySkillID: mySkillID == freezed ? _value.mySkillID : mySkillID as String,
+      pkcNumber: pkcNumber == freezed ? _value.pkcNumber : pkcNumber as int,
+      playerNumber:
+          playerNumber == freezed ? _value.playerNumber : playerNumber as int,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$DuelistSettingCopyWith<$Res>
+    implements $DuelistSettingCopyWith<$Res> {
+  factory _$DuelistSettingCopyWith(
+          _DuelistSetting value, $Res Function(_DuelistSetting) then) =
+      __$DuelistSettingCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String myDeckID, String mySkillID, int pkcNumber, int playerNumber});
+}
+
+/// @nodoc
+class __$DuelistSettingCopyWithImpl<$Res>
+    extends _$DuelistSettingCopyWithImpl<$Res>
+    implements _$DuelistSettingCopyWith<$Res> {
+  __$DuelistSettingCopyWithImpl(
+      _DuelistSetting _value, $Res Function(_DuelistSetting) _then)
+      : super(_value, (v) => _then(v as _DuelistSetting));
+
+  @override
+  _DuelistSetting get _value => super._value as _DuelistSetting;
+
+  @override
+  $Res call({
+    Object myDeckID = freezed,
+    Object mySkillID = freezed,
+    Object pkcNumber = freezed,
+    Object playerNumber = freezed,
+  }) {
+    return _then(_DuelistSetting(
+      myDeckID: myDeckID == freezed ? _value.myDeckID : myDeckID as String,
+      mySkillID: mySkillID == freezed ? _value.mySkillID : mySkillID as String,
+      pkcNumber: pkcNumber == freezed ? _value.pkcNumber : pkcNumber as int,
+      playerNumber:
+          playerNumber == freezed ? _value.playerNumber : playerNumber as int,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_DuelistSetting
+    with DiagnosticableTreeMixin
+    implements _DuelistSetting {
+  const _$_DuelistSetting(
+      {this.myDeckID = '',
+      this.mySkillID = '',
+      this.pkcNumber = 0,
+      this.playerNumber = 0})
+      : assert(myDeckID != null),
+        assert(mySkillID != null),
+        assert(pkcNumber != null),
+        assert(playerNumber != null);
+
+  @JsonKey(defaultValue: '')
+  @override
+  final String myDeckID;
+  @JsonKey(defaultValue: '')
+  @override
+  final String mySkillID;
+  @JsonKey(defaultValue: 0)
+  @override
+  final int pkcNumber;
+  @JsonKey(defaultValue: 0)
+  @override
+  final int playerNumber;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'DuelistSetting(myDeckID: $myDeckID, mySkillID: $mySkillID, pkcNumber: $pkcNumber, playerNumber: $playerNumber)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'DuelistSetting'))
+      ..add(DiagnosticsProperty('myDeckID', myDeckID))
+      ..add(DiagnosticsProperty('mySkillID', mySkillID))
+      ..add(DiagnosticsProperty('pkcNumber', pkcNumber))
+      ..add(DiagnosticsProperty('playerNumber', playerNumber));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _DuelistSetting &&
+            (identical(other.myDeckID, myDeckID) ||
+                const DeepCollectionEquality()
+                    .equals(other.myDeckID, myDeckID)) &&
+            (identical(other.mySkillID, mySkillID) ||
+                const DeepCollectionEquality()
+                    .equals(other.mySkillID, mySkillID)) &&
+            (identical(other.pkcNumber, pkcNumber) ||
+                const DeepCollectionEquality()
+                    .equals(other.pkcNumber, pkcNumber)) &&
+            (identical(other.playerNumber, playerNumber) ||
+                const DeepCollectionEquality()
+                    .equals(other.playerNumber, playerNumber)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(myDeckID) ^
+      const DeepCollectionEquality().hash(mySkillID) ^
+      const DeepCollectionEquality().hash(pkcNumber) ^
+      const DeepCollectionEquality().hash(playerNumber);
+
+  @override
+  _$DuelistSettingCopyWith<_DuelistSetting> get copyWith =>
+      __$DuelistSettingCopyWithImpl<_DuelistSetting>(this, _$identity);
+}
+
+abstract class _DuelistSetting implements DuelistSetting {
+  const factory _DuelistSetting(
+      {String myDeckID,
+      String mySkillID,
+      int pkcNumber,
+      int playerNumber}) = _$_DuelistSetting;
+
+  @override
+  String get myDeckID;
+  @override
+  String get mySkillID;
+  @override
+  int get pkcNumber;
+  @override
+  int get playerNumber;
+  @override
+  _$DuelistSettingCopyWith<_DuelistSetting> get copyWith;
+}

--- a/lib/models/game_record/game_record.dart
+++ b/lib/models/game_record/game_record.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:flutter/foundation.dart';
+
+part 'game_record.freezed.dart';
+
+@freezed
+abstract class GameRecord with _$GameRecord {
+  const factory GameRecord({
+    @required String id,
+    @required DateTime timestamp,
+    @required Result result,
+    @required First first,
+    @required int myPlayerNum,
+    @required String myDeckID,
+    @required String mySkillID,
+    @required int oppPlayerNum,
+    String oppDeckID,
+    String oppSkillID,
+  }) = _GameRecord;
+}
+
+enum Result { win, lose }
+
+enum First { play, draw }

--- a/lib/models/game_record/game_record.freezed.dart
+++ b/lib/models/game_record/game_record.freezed.dart
@@ -1,0 +1,334 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+
+part of 'game_record.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+class _$GameRecordTearOff {
+  const _$GameRecordTearOff();
+
+// ignore: unused_element
+  _GameRecord call(
+      {@required String id,
+      @required DateTime timestamp,
+      @required Result result,
+      @required First first,
+      @required int myPlayerNum,
+      @required String myDeckID,
+      @required String mySkillID,
+      @required int oppPlayerNum,
+      String oppDeckID,
+      String oppSkillID}) {
+    return _GameRecord(
+      id: id,
+      timestamp: timestamp,
+      result: result,
+      first: first,
+      myPlayerNum: myPlayerNum,
+      myDeckID: myDeckID,
+      mySkillID: mySkillID,
+      oppPlayerNum: oppPlayerNum,
+      oppDeckID: oppDeckID,
+      oppSkillID: oppSkillID,
+    );
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $GameRecord = _$GameRecordTearOff();
+
+/// @nodoc
+mixin _$GameRecord {
+  String get id;
+  DateTime get timestamp;
+  Result get result;
+  First get first;
+  int get myPlayerNum;
+  String get myDeckID;
+  String get mySkillID;
+  int get oppPlayerNum;
+  String get oppDeckID;
+  String get oppSkillID;
+
+  $GameRecordCopyWith<GameRecord> get copyWith;
+}
+
+/// @nodoc
+abstract class $GameRecordCopyWith<$Res> {
+  factory $GameRecordCopyWith(
+          GameRecord value, $Res Function(GameRecord) then) =
+      _$GameRecordCopyWithImpl<$Res>;
+  $Res call(
+      {String id,
+      DateTime timestamp,
+      Result result,
+      First first,
+      int myPlayerNum,
+      String myDeckID,
+      String mySkillID,
+      int oppPlayerNum,
+      String oppDeckID,
+      String oppSkillID});
+}
+
+/// @nodoc
+class _$GameRecordCopyWithImpl<$Res> implements $GameRecordCopyWith<$Res> {
+  _$GameRecordCopyWithImpl(this._value, this._then);
+
+  final GameRecord _value;
+  // ignore: unused_field
+  final $Res Function(GameRecord) _then;
+
+  @override
+  $Res call({
+    Object id = freezed,
+    Object timestamp = freezed,
+    Object result = freezed,
+    Object first = freezed,
+    Object myPlayerNum = freezed,
+    Object myDeckID = freezed,
+    Object mySkillID = freezed,
+    Object oppPlayerNum = freezed,
+    Object oppDeckID = freezed,
+    Object oppSkillID = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: id == freezed ? _value.id : id as String,
+      timestamp:
+          timestamp == freezed ? _value.timestamp : timestamp as DateTime,
+      result: result == freezed ? _value.result : result as Result,
+      first: first == freezed ? _value.first : first as First,
+      myPlayerNum:
+          myPlayerNum == freezed ? _value.myPlayerNum : myPlayerNum as int,
+      myDeckID: myDeckID == freezed ? _value.myDeckID : myDeckID as String,
+      mySkillID: mySkillID == freezed ? _value.mySkillID : mySkillID as String,
+      oppPlayerNum:
+          oppPlayerNum == freezed ? _value.oppPlayerNum : oppPlayerNum as int,
+      oppDeckID: oppDeckID == freezed ? _value.oppDeckID : oppDeckID as String,
+      oppSkillID:
+          oppSkillID == freezed ? _value.oppSkillID : oppSkillID as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$GameRecordCopyWith<$Res> implements $GameRecordCopyWith<$Res> {
+  factory _$GameRecordCopyWith(
+          _GameRecord value, $Res Function(_GameRecord) then) =
+      __$GameRecordCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {String id,
+      DateTime timestamp,
+      Result result,
+      First first,
+      int myPlayerNum,
+      String myDeckID,
+      String mySkillID,
+      int oppPlayerNum,
+      String oppDeckID,
+      String oppSkillID});
+}
+
+/// @nodoc
+class __$GameRecordCopyWithImpl<$Res> extends _$GameRecordCopyWithImpl<$Res>
+    implements _$GameRecordCopyWith<$Res> {
+  __$GameRecordCopyWithImpl(
+      _GameRecord _value, $Res Function(_GameRecord) _then)
+      : super(_value, (v) => _then(v as _GameRecord));
+
+  @override
+  _GameRecord get _value => super._value as _GameRecord;
+
+  @override
+  $Res call({
+    Object id = freezed,
+    Object timestamp = freezed,
+    Object result = freezed,
+    Object first = freezed,
+    Object myPlayerNum = freezed,
+    Object myDeckID = freezed,
+    Object mySkillID = freezed,
+    Object oppPlayerNum = freezed,
+    Object oppDeckID = freezed,
+    Object oppSkillID = freezed,
+  }) {
+    return _then(_GameRecord(
+      id: id == freezed ? _value.id : id as String,
+      timestamp:
+          timestamp == freezed ? _value.timestamp : timestamp as DateTime,
+      result: result == freezed ? _value.result : result as Result,
+      first: first == freezed ? _value.first : first as First,
+      myPlayerNum:
+          myPlayerNum == freezed ? _value.myPlayerNum : myPlayerNum as int,
+      myDeckID: myDeckID == freezed ? _value.myDeckID : myDeckID as String,
+      mySkillID: mySkillID == freezed ? _value.mySkillID : mySkillID as String,
+      oppPlayerNum:
+          oppPlayerNum == freezed ? _value.oppPlayerNum : oppPlayerNum as int,
+      oppDeckID: oppDeckID == freezed ? _value.oppDeckID : oppDeckID as String,
+      oppSkillID:
+          oppSkillID == freezed ? _value.oppSkillID : oppSkillID as String,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_GameRecord with DiagnosticableTreeMixin implements _GameRecord {
+  const _$_GameRecord(
+      {@required this.id,
+      @required this.timestamp,
+      @required this.result,
+      @required this.first,
+      @required this.myPlayerNum,
+      @required this.myDeckID,
+      @required this.mySkillID,
+      @required this.oppPlayerNum,
+      this.oppDeckID,
+      this.oppSkillID})
+      : assert(id != null),
+        assert(timestamp != null),
+        assert(result != null),
+        assert(first != null),
+        assert(myPlayerNum != null),
+        assert(myDeckID != null),
+        assert(mySkillID != null),
+        assert(oppPlayerNum != null);
+
+  @override
+  final String id;
+  @override
+  final DateTime timestamp;
+  @override
+  final Result result;
+  @override
+  final First first;
+  @override
+  final int myPlayerNum;
+  @override
+  final String myDeckID;
+  @override
+  final String mySkillID;
+  @override
+  final int oppPlayerNum;
+  @override
+  final String oppDeckID;
+  @override
+  final String oppSkillID;
+
+  @override
+  String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
+    return 'GameRecord(id: $id, timestamp: $timestamp, result: $result, first: $first, myPlayerNum: $myPlayerNum, myDeckID: $myDeckID, mySkillID: $mySkillID, oppPlayerNum: $oppPlayerNum, oppDeckID: $oppDeckID, oppSkillID: $oppSkillID)';
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties
+      ..add(DiagnosticsProperty('type', 'GameRecord'))
+      ..add(DiagnosticsProperty('id', id))
+      ..add(DiagnosticsProperty('timestamp', timestamp))
+      ..add(DiagnosticsProperty('result', result))
+      ..add(DiagnosticsProperty('first', first))
+      ..add(DiagnosticsProperty('myPlayerNum', myPlayerNum))
+      ..add(DiagnosticsProperty('myDeckID', myDeckID))
+      ..add(DiagnosticsProperty('mySkillID', mySkillID))
+      ..add(DiagnosticsProperty('oppPlayerNum', oppPlayerNum))
+      ..add(DiagnosticsProperty('oppDeckID', oppDeckID))
+      ..add(DiagnosticsProperty('oppSkillID', oppSkillID));
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _GameRecord &&
+            (identical(other.id, id) ||
+                const DeepCollectionEquality().equals(other.id, id)) &&
+            (identical(other.timestamp, timestamp) ||
+                const DeepCollectionEquality()
+                    .equals(other.timestamp, timestamp)) &&
+            (identical(other.result, result) ||
+                const DeepCollectionEquality().equals(other.result, result)) &&
+            (identical(other.first, first) ||
+                const DeepCollectionEquality().equals(other.first, first)) &&
+            (identical(other.myPlayerNum, myPlayerNum) ||
+                const DeepCollectionEquality()
+                    .equals(other.myPlayerNum, myPlayerNum)) &&
+            (identical(other.myDeckID, myDeckID) ||
+                const DeepCollectionEquality()
+                    .equals(other.myDeckID, myDeckID)) &&
+            (identical(other.mySkillID, mySkillID) ||
+                const DeepCollectionEquality()
+                    .equals(other.mySkillID, mySkillID)) &&
+            (identical(other.oppPlayerNum, oppPlayerNum) ||
+                const DeepCollectionEquality()
+                    .equals(other.oppPlayerNum, oppPlayerNum)) &&
+            (identical(other.oppDeckID, oppDeckID) ||
+                const DeepCollectionEquality()
+                    .equals(other.oppDeckID, oppDeckID)) &&
+            (identical(other.oppSkillID, oppSkillID) ||
+                const DeepCollectionEquality()
+                    .equals(other.oppSkillID, oppSkillID)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(id) ^
+      const DeepCollectionEquality().hash(timestamp) ^
+      const DeepCollectionEquality().hash(result) ^
+      const DeepCollectionEquality().hash(first) ^
+      const DeepCollectionEquality().hash(myPlayerNum) ^
+      const DeepCollectionEquality().hash(myDeckID) ^
+      const DeepCollectionEquality().hash(mySkillID) ^
+      const DeepCollectionEquality().hash(oppPlayerNum) ^
+      const DeepCollectionEquality().hash(oppDeckID) ^
+      const DeepCollectionEquality().hash(oppSkillID);
+
+  @override
+  _$GameRecordCopyWith<_GameRecord> get copyWith =>
+      __$GameRecordCopyWithImpl<_GameRecord>(this, _$identity);
+}
+
+abstract class _GameRecord implements GameRecord {
+  const factory _GameRecord(
+      {@required String id,
+      @required DateTime timestamp,
+      @required Result result,
+      @required First first,
+      @required int myPlayerNum,
+      @required String myDeckID,
+      @required String mySkillID,
+      @required int oppPlayerNum,
+      String oppDeckID,
+      String oppSkillID}) = _$_GameRecord;
+
+  @override
+  String get id;
+  @override
+  DateTime get timestamp;
+  @override
+  Result get result;
+  @override
+  First get first;
+  @override
+  int get myPlayerNum;
+  @override
+  String get myDeckID;
+  @override
+  String get mySkillID;
+  @override
+  int get oppPlayerNum;
+  @override
+  String get oppDeckID;
+  @override
+  String get oppSkillID;
+  @override
+  _$GameRecordCopyWith<_GameRecord> get copyWith;
+}

--- a/lib/repositories/value_persistence_repository/value_persistence_repo.dart
+++ b/lib/repositories/value_persistence_repository/value_persistence_repo.dart
@@ -1,0 +1,15 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ValuePersistenceRepository {
+  ValuePersistenceRepository();
+
+  Future<String> getString(String key) async {
+    var prefs = await SharedPreferences.getInstance();
+    return prefs.getString(key);
+  }
+
+  Future<void> setString(String key, String value) async {
+    var prefs = await SharedPreferences.getInstance();
+    await prefs.setString(key, value);
+  }
+}

--- a/lib/views/home/duelist_setting_card.dart
+++ b/lib/views/home/duelist_setting_card.dart
@@ -1,10 +1,9 @@
 import 'package:PreKCCupApp/controllers/d_setting_controller/d_setting_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:dropdown_search/dropdown_search.dart';
 
 import '../../models/duelist_setting/duelist_setting.dart';
-
-import 'dart:math';
 
 class DuelistSettingCard extends StatelessWidget {
   @override
@@ -21,21 +20,28 @@ class DuelistSettingCard extends StatelessWidget {
                 Text(
                   'Deck Theme',
                 ),
-                Text(
-                  context.select<DuelistSetting, String>((s) => s.myDeckID),
-                ),
-                RaisedButton(
-                  child: Text('set abc'),
-                  onPressed: () => context
-                      .read<DSettingController>()
-                      .setMyDeck(Random().nextInt(120).toString()),
-                  textColor: Theme.of(context).colorScheme.onPrimary,
+                DropdownSearch(
+                  showSearchBox: true,
+                  items: ['カラクリ: KARAKURI', 'BF: BLACKWINGS', '不知火: SHIRANUI'],
+                  selectedItem:
+                      context.select<DuelistSetting, String>((s) => s.myDeckID),
+                  onChanged: (i) =>
+                      context.read<DSettingController>().setMyDeck(i),
                 ),
                 Text(
                   'Skill',
                 ),
-                Text(
-                  context.select<DuelistSetting, String>((s) => s.mySkillID),
+                DropdownSearch(
+                  showSearchBox: true,
+                  items: [
+                    'リスタート: Restart',
+                    '頂に立つ者: Peak Performance',
+                    'レベル上昇: Level Augmentation',
+                  ],
+                  selectedItem: context
+                      .select<DuelistSetting, String>((s) => s.mySkillID),
+                  onChanged: (i) =>
+                      context.read<DSettingController>().setMySkill(i),
                 ),
               ],
             ),

--- a/lib/views/home/duelist_setting_card.dart
+++ b/lib/views/home/duelist_setting_card.dart
@@ -1,0 +1,47 @@
+import 'package:PreKCCupApp/controllers/d_setting_controller/d_setting_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../models/duelist_setting/duelist_setting.dart';
+
+import 'dart:math';
+
+class DuelistSettingCard extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 8.0),
+      child: Card(
+        elevation: 2.0,
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Center(
+            child: Column(
+              children: [
+                Text(
+                  'Deck Theme',
+                ),
+                Text(
+                  context.select<DuelistSetting, String>((s) => s.myDeckID),
+                ),
+                RaisedButton(
+                  child: Text('set abc'),
+                  onPressed: () => context
+                      .read<DSettingController>()
+                      .setMyDeck(Random().nextInt(120).toString()),
+                  textColor: Theme.of(context).colorScheme.onPrimary,
+                ),
+                Text(
+                  'Skill',
+                ),
+                Text(
+                  context.select<DuelistSetting, String>((s) => s.mySkillID),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/views/home/home_view.dart
+++ b/lib/views/home/home_view.dart
@@ -2,24 +2,29 @@ import 'package:flutter/material.dart';
 
 import 'login_background.dart';
 import 'app_bar_column.dart';
+import 'duelist_setting_card.dart';
 import 'action_menu_card.dart';
 
-class HomeView extends StatelessWidget {
-  Widget _allCards(BuildContext context) {
+class _allCards extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
     final h = MediaQuery.of(context).size.height * 0.01;
+
     return SingleChildScrollView(
       child: Column(
         children: <Widget>[
           AppBarColumn(),
           SizedBox(height: h),
-          ActionMenuCard(),
+          DuelistSettingCard(),
           SizedBox(height: h),
           ActionMenuCard(),
         ],
       ),
     );
   }
+}
 
+class HomeView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -27,7 +32,7 @@ class HomeView extends StatelessWidget {
         fit: StackFit.expand,
         children: <Widget>[
           LoginBackground(),
-          _allCards(context),
+          _allCards(),
         ],
       ),
     );

--- a/lib/views/root_view.dart
+++ b/lib/views/root_view.dart
@@ -1,16 +1,22 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:provider/provider.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 
 import 'signin/signin_view.dart';
 import 'home/home_view.dart';
 import '../models/auth_state/auth_state.dart';
+import '../models/duelist_setting/duelist_setting.dart';
+import '../controllers/d_setting_controller/d_setting_controller.dart';
 
 class RootView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return (context.select<AuthState, User>((s) => s.user) == null)
         ? SigninView()
-        : HomeView();
+        : StateNotifierProvider<DSettingController, DuelistSetting>(
+            create: (context) => DSettingController(),
+            child: HomeView(),
+          );
   }
 }

--- a/lib/views/root_view.dart
+++ b/lib/views/root_view.dart
@@ -8,15 +8,18 @@ import 'home/home_view.dart';
 import '../models/auth_state/auth_state.dart';
 import '../models/duelist_setting/duelist_setting.dart';
 import '../controllers/d_setting_controller/d_setting_controller.dart';
+import '../repositories/value_persistence_repository/value_persistence_repo.dart';
 
 class RootView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return (context.select<AuthState, User>((s) => s.user) == null)
         ? SigninView()
-        : StateNotifierProvider<DSettingController, DuelistSetting>(
-            create: (context) => DSettingController(),
-            child: HomeView(),
-          );
+        : Provider(
+            create: (_) => ValuePersistenceRepository(),
+            child: StateNotifierProvider<DSettingController, DuelistSetting>(
+              create: (context) => DSettingController(),
+              child: HomeView(),
+            ));
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -204,6 +204,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0-nullsafety"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.2.1"
   firebase:
     dependency: transitive
     description:
@@ -485,6 +499,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0-nullsafety"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+2"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4+1"
   pedantic:
     dependency: transitive
     description:
@@ -492,6 +527,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -506,6 +548,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.13"
   provider:
     dependency: "direct main"
     description:
@@ -534,6 +583,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.12"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.2+2"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+10"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2+7"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+1"
   shelf:
     dependency: transitive
     description:
@@ -651,6 +742,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.7.3"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.2"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,6 +197,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.6"
+  dropdown_search:
+    dependency: "direct main"
+    description:
+      name: dropdown_search
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.4"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   state_notifier: ^0.6.0
   flutter_state_notifier: ^0.6.1
   freezed_annotation: ^0.12.0
+  shared_preferences: '>=0.5.12 <2.0.0'
 
   firebase_core: 0.5.0
   firebase_auth: ^0.18.0+1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,8 @@ dependencies:
   state_notifier: ^0.6.0
   flutter_state_notifier: ^0.6.1
   freezed_annotation: ^0.12.0
-  shared_preferences: '>=0.5.12 <2.0.0'
+  shared_preferences: ^0.5.12
+  dropdown_search: ^0.4.4
 
   firebase_core: 0.5.0
   firebase_auth: ^0.18.0+1


### PR DESCRIPTION
- [x] 諸々に必要な entity model を定義
- [x] 自分のデッキとスキルを画面に表示
- [x] ストレージに設定情報を保存して永続化
- [x] デッキとスキルを画面から編集（選択）できるようにする

デッキとスキルのリストをサーバから取ってくるところは別のPRで。
ここでは手元にもっている仮のリストを使って動かすところまでかなぁ、と考え中。